### PR TITLE
Not ignoring (TV) and (S)

### DIFF
--- a/fa_scrapper/cli.py
+++ b/fa_scrapper/cli.py
@@ -32,7 +32,7 @@ def main():
     parser.add_argument("--all-lists", action="store_true", help="Download all lists")
     parser.add_argument(
         "--ignore",
-        help="Ignore one of the following categories (can be used multiple times): TVS (TV series), TVMS (TV miniseries), TV (TV), S (Short)",
+        help="Ignore a category (TVS/TVMS/TV/S). This can be used multiple times. By default, all categories are included.",
         type=FACategory,
         choices=FACategory,
         action="append",

--- a/fa_scrapper/cli.py
+++ b/fa_scrapper/cli.py
@@ -12,6 +12,7 @@ from .fa_scrapper import (
 
 __version__ = "0.1.1"
 
+
 def main():
     """Main function"""
     parser = argparse.ArgumentParser(
@@ -34,12 +35,12 @@ def main():
         help="Ignore one of the following categories (can be used multiple times): TVS (TV series), TVMS (TV miniseries), TV (TV), S (Short)",
         type=FACategory,
         choices=FACategory,
-        action='append',
+        action="append",
         default=[],
-        )
+    )
 
     args = parser.parse_args()
-    
+
     if args.csv:
         export_file = args.csv[0]
     elif args.list:

--- a/fa_scrapper/cli.py
+++ b/fa_scrapper/cli.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument("--all-lists", action="store_true", help="Download all lists")
     parser.add_argument(
         "--ignore",
-        help="Ignore a category (can be used multiple times)",
+        help="Ignore one of the following categories (can be used multiple times): TVS (TV series), TVMS (TV miniseries), TV (TV), S (Short)",
         type=FACategory,
         choices=FACategory,
         action='append',

--- a/fa_scrapper/cli.py
+++ b/fa_scrapper/cli.py
@@ -7,10 +7,10 @@ from .fa_scrapper import (
     get_profile_data,
     save_to_csv,
     save_lists_to_csv,
+    FACategory,
 )
 
 __version__ = "0.1.1"
-
 
 def main():
     """Main function"""
@@ -29,9 +29,17 @@ def main():
         choices={"es", "en"},
     )
     parser.add_argument("--all-lists", action="store_true", help="Download all lists")
+    parser.add_argument(
+        "--ignore",
+        help="Ignore a category (can be used multiple times)",
+        type=FACategory,
+        choices=FACategory,
+        action='append',
+        default=[],
+        )
 
     args = parser.parse_args()
-
+    
     if args.csv:
         export_file = args.csv[0]
     elif args.list:
@@ -64,13 +72,13 @@ def main():
                 sys.exit()
 
     if args.all_lists:
-        save_lists_to_csv(args.id, args.lang[0], export_file)
+        save_lists_to_csv(args.id, args.lang[0], export_file, args.ignore)
     else:
         try:
             if args.list:
-                data = get_list_data(args.id, args.list, args.lang[0])
+                data = get_list_data(args.id, args.list, args.lang[0], args.ignore)
             else:
-                data = get_profile_data(args.id, args.lang[0])
+                data = get_profile_data(args.id, args.lang[0], args.ignore)
         except ValueError as v:
             print("Error:", v)
             sys.exit()

--- a/fa_scrapper/fa_scrapper.py
+++ b/fa_scrapper/fa_scrapper.py
@@ -27,10 +27,14 @@ from enum import Enum
 
 class FACategory(Enum):
     """Enum holding filmaffinity categories"""
-    TVS = auto()
-    TVMS = auto()
-    TV = auto()
-    S = auto()
+    TVS = "TVS"
+    TVMS = "TVMS"
+    TV = "TV"
+    S = "S"
+
+    def __str__(self):
+        """Returns category"""
+        return self.value
 
 # FilmAffinity root URL
 FA_ROOT_URL = "https://www.filmaffinity.com/{lang}/"
@@ -94,7 +98,7 @@ def is_chosen_category(tag, lang, ignore_list):
 
     skip = map(skipdct.get, ignore_list)
 
-    return not any(title.endswith(suffix) for suffix in )
+    return not any(title.endswith(suffix) for suffix in skip)
 
 
 def pages_from(template):

--- a/fa_scrapper/fa_scrapper.py
+++ b/fa_scrapper/fa_scrapper.py
@@ -27,7 +27,7 @@ from enum import Enum
 
 
 class FACategory(Enum):
-    """Enum holding filmaffinity categories"""
+    """FilmAffinity categories"""
 
     TVS = "TVS"
     TVMS = "TVMS"

--- a/fa_scrapper/fa_scrapper.py
+++ b/fa_scrapper/fa_scrapper.py
@@ -27,6 +27,7 @@ from enum import Enum
 
 class FACategory(Enum):
     """Enum holding filmaffinity categories"""
+    
     TVS = "TVS"
     TVMS = "TVMS"
     TV = "TV"
@@ -35,6 +36,7 @@ class FACategory(Enum):
     def __str__(self):
         """Returns category"""
         return self.value
+
 
 # FilmAffinity root URL
 FA_ROOT_URL = "https://www.filmaffinity.com/{lang}/"
@@ -86,15 +88,19 @@ def is_chosen_category(tag, lang, ignore_list):
     title = tag.find_all(class_="mc-title")[0].a.string.strip()
 
     if lang == "es":
-        skipdct = {FACategory.TVS : "(Serie de TV)",
-                   FACategory.TVMS: "(Miniserie de TV)",
-                   FACategory.TV: "(TV)",
-                   FACategory.S: "(C)"}
+        skipdct = {
+            FACategory.TVS : "(Serie de TV)",
+            FACategory.TVMS: "(Miniserie de TV)",
+            FACategory.TV: "(TV)",
+            FACategory.S: "(C)"
+        }
     else:
-        skipdct = {FACategory.TVS : "(TV Series)",
-                   FACategory.TVMS: "(TV Miniseries)",
-                   FACategory.TV: "(TV)",
-                   FACategory.S: "(S)"}
+        skipdct = {
+            FACategory.TVS : "(TV Series)",
+            FACategory.TVMS: "(TV Miniseries)",
+            FACategory.TV: "(TV)",
+            FACategory.S: "(S)"
+        }
 
     skip = map(skipdct.get, ignore_list)
 
@@ -119,6 +125,7 @@ def pages_from(template):
         else:
             print("Page {n}. Download complete!".format(n=n - 1))
         n += 1
+
 
 def get_profile_data(user_id, lang, ignore_list):
     """Yields films rated by user given user id"""
@@ -145,6 +152,7 @@ def get_profile_data(user_id, lang, ignore_list):
                     "Rating10": tag.find_all(class_="ur-mr-rat")[0].string,
                 }
 
+
 def get_list_data(user_id, list_id, lang, ignore_list):
     """Yields films from list given list id"""
 
@@ -162,7 +170,8 @@ def get_list_data(user_id, list_id, lang, ignore_list):
                     "Title": title.string.strip(),
                     "Year": title.next_sibling.strip()[1:-1],
                     "Directors": get_directors(tag),
-                    }
+                }
+                
 
 def get_user_lists(user_id, lang):
     """Yields all lists from the given user"""
@@ -180,6 +189,7 @@ def get_user_lists(user_id, lang):
             url = tag.a.get("href")
             list_id = url[url.find("list_id=") + len("list_id=") :]
             yield [list_id, list_name]
+
 
 def save_lists_to_csv(user_id, lang, pattern, ignore_list):
     """Extracts all lists from a user and saves them independently"""

--- a/fa_scrapper/fa_scrapper.py
+++ b/fa_scrapper/fa_scrapper.py
@@ -25,9 +25,10 @@ import bs4
 
 from enum import Enum
 
+
 class FACategory(Enum):
     """Enum holding filmaffinity categories"""
-    
+
     TVS = "TVS"
     TVMS = "TVMS"
     TV = "TV"
@@ -89,17 +90,17 @@ def is_chosen_category(tag, lang, ignore_list):
 
     if lang == "es":
         skipdct = {
-            FACategory.TVS : "(Serie de TV)",
+            FACategory.TVS: "(Serie de TV)",
             FACategory.TVMS: "(Miniserie de TV)",
             FACategory.TV: "(TV)",
-            FACategory.S: "(C)"
+            FACategory.S: "(C)",
         }
     else:
         skipdct = {
-            FACategory.TVS : "(TV Series)",
+            FACategory.TVS: "(TV Series)",
             FACategory.TVMS: "(TV Miniseries)",
             FACategory.TV: "(TV)",
-            FACategory.S: "(S)"
+            FACategory.S: "(S)",
         }
 
     skip = map(skipdct.get, ignore_list)
@@ -171,7 +172,7 @@ def get_list_data(user_id, list_id, lang, ignore_list):
                     "Year": title.next_sibling.strip()[1:-1],
                     "Directors": get_directors(tag),
                 }
-                
+
 
 def get_user_lists(user_id, lang):
     """Yields all lists from the given user"""

--- a/fa_scrapper/fa_scrapper.py
+++ b/fa_scrapper/fa_scrapper.py
@@ -23,6 +23,14 @@ import locale
 import requests
 import bs4
 
+from enum import Enum
+
+class FACategory(Enum):
+    """Enum holding filmaffinity categories"""
+    TVS = auto()
+    TVMS = auto()
+    TV = auto()
+    S = auto()
 
 # FilmAffinity root URL
 FA_ROOT_URL = "https://www.filmaffinity.com/{lang}/"
@@ -68,17 +76,25 @@ def get_directors(tag):
     )
 
 
-def is_film(tag, lang):
-    """Checks if given tag is a film"""
+def is_chosen_category(tag, lang, ignore_list):
+    """Checks if given tag is within the chosen categories"""
 
     title = tag.find_all(class_="mc-title")[0].a.string.strip()
 
     if lang == "es":
-        skip = ["(Serie de TV)", "(Miniserie de TV)", "(TV)", "(C)"]
+        skipdct = {FACategory.TVS : "(Serie de TV)",
+                   FACategory.TVMS: "(Miniserie de TV)",
+                   FACategory.TV: "(TV)",
+                   FACategory.S: "(C)"}
     else:
-        skip = ["(TV Series)", "(TV Miniseries)", "(TV)", "(S)"]
+        skipdct = {FACategory.TVS : "(TV Series)",
+                   FACategory.TVMS: "(TV Miniseries)",
+                   FACategory.TV: "(TV)",
+                   FACategory.S: "(S)"}
 
-    return not any(title.endswith(suffix) for suffix in skip)
+    skip = map(skipdct.get, ignore_list)
+
+    return not any(title.endswith(suffix) for suffix in )
 
 
 def pages_from(template):
@@ -100,8 +116,7 @@ def pages_from(template):
             print("Page {n}. Download complete!".format(n=n - 1))
         n += 1
 
-
-def get_profile_data(user_id, lang):
+def get_profile_data(user_id, lang, ignore_list):
     """Yields films rated by user given user id"""
 
     FA = (FA_ROOT_URL + "userratings.php?user_id={id}&p={{}}&orderby=4").format(
@@ -115,7 +130,7 @@ def get_profile_data(user_id, lang):
         for tag in tags:
             if tag["class"] == ["user-ratings-header"]:
                 cur_date = get_date(tag, lang)
-            elif is_film(tag, lang):
+            elif is_chosen_category(tag, lang, ignore_list):
                 title = tag.find_all(class_="mc-title")[0].a
                 yield {
                     "Title": title.string.strip(),
@@ -126,8 +141,7 @@ def get_profile_data(user_id, lang):
                     "Rating10": tag.find_all(class_="ur-mr-rat")[0].string,
                 }
 
-
-def get_list_data(user_id, list_id, lang):
+def get_list_data(user_id, list_id, lang, ignore_list):
     """Yields films from list given list id"""
 
     FA = (
@@ -138,13 +152,13 @@ def get_list_data(user_id, list_id, lang):
         tags = page.find_all(class_=["movie-wrapper"])
 
         for tag in tags:
-            title = tag.find_all(class_="mc-title")[0].a
-            yield {
-                "Title": title.string.strip(),
-                "Year": title.next_sibling.strip()[1:-1],
-                "Directors": get_directors(tag),
-            }
-
+            if is_chosen_category(tag, lang, ignore_list):
+                title = tag.find_all(class_="mc-title")[0].a
+                yield {
+                    "Title": title.string.strip(),
+                    "Year": title.next_sibling.strip()[1:-1],
+                    "Directors": get_directors(tag),
+                    }
 
 def get_user_lists(user_id, lang):
     """Yields all lists from the given user"""
@@ -163,12 +177,11 @@ def get_user_lists(user_id, lang):
             list_id = url[url.find("list_id=") + len("list_id=") :]
             yield [list_id, list_name]
 
-
-def save_lists_to_csv(user_id, lang, pattern):
+def save_lists_to_csv(user_id, lang, pattern, ignore_list):
     """Extracts all lists from a user and saves them independently"""
 
     for user_list in get_user_lists(user_id, lang):
-        films = get_list_data(user_id, user_list[0], lang)
+        films = get_list_data(user_id, user_list[0], lang, ignore_list)
         save_to_csv(films, pattern.format(user_list[1]))
 
 


### PR DESCRIPTION
This pull request adresses #5 by adding a new `Enum` type to fa-scrapper with all the categories that could be ignored, adding one new argument to the cli utility that lets the user ignore categories and checking every tag belongs to one of the chosen categories.